### PR TITLE
Remove invisible Unicode characters from window titles

### DIFF
--- a/captured.go
+++ b/captured.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image"
 	"strings"
+	"unicode"
 )
 
 const (
@@ -32,7 +33,13 @@ type base struct {
 func (b *base) CaptureWindowByTitle(contains string, options Options) (*image.RGBA, error) {
 	windowList, _ := Captured.ListWindows()
 	for _, window := range windowList {
-		if !strings.Contains(strings.ToLower(window.Title), strings.ToLower(contains)) {
+		windowTitle := strings.Map(func(r rune) rune {
+			if unicode.IsPrint(r) {
+				return r
+			}
+			return -1
+		}, window.Title)
+		if !strings.Contains(strings.ToLower(windowTitle), strings.ToLower(contains)) {
 			continue
 		}
 		img, err := Captured.CaptureWindow(window, options)


### PR DESCRIPTION
This fixes window titles not matching due to invisible Unicode characters. Tested on Windows 11. I used `IsPrint` instead of `IsGraphic` since `IsGraphic` didn't catch `\u00a0`.

Before:
![image](https://user-images.githubusercontent.com/12671409/178132548-eeb4ad54-16a4-466d-9c1d-587edd9478e3.png)

After:
![image](https://user-images.githubusercontent.com/12671409/178132551-b2bb2200-7a9c-4d07-9ebf-88fe781ab393.png)
